### PR TITLE
Added edit functionality to TaxTable

### DIFF
--- a/src/Settings/Settings.tsx
+++ b/src/Settings/Settings.tsx
@@ -1,4 +1,3 @@
-import Grid from '@mui/system/Unstable_Grid';
 import React from 'react';
 import PageHeader from '../common/PageHeader';
 import { taxTableCallback } from '../common/constants';

--- a/src/Settings/TaxTable/TaxTable.scss
+++ b/src/Settings/TaxTable/TaxTable.scss
@@ -7,7 +7,25 @@
   padding: 0 6px;
   border-radius: 6px;
 
+  .edit-table {
+    display: flex;
+    justify-content: right;
+  }
+
   .column-header {
     font-weight: 600;
+  }
+
+  .footer-message {
+    display: flex;
+    align-items: center;
+  }
+
+  .edit-action-btn {
+    background-color: $grid-taxtable-edit-btn-wrapper;
+
+    &:hover {
+      background-color: $grid-taxtable-edit-btn-wrapper;
+    }
   }
 }

--- a/src/Settings/TaxTable/TaxTable.tsx
+++ b/src/Settings/TaxTable/TaxTable.tsx
@@ -1,8 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { taxBracket } from '../types';
 import { getPayPeriodValue } from '../helper';
 import Grid from '@mui/system/Unstable_Grid';
+import FormGroup from '@mui/material/FormGroup';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Switch from '@mui/material/Switch';
 import './TaxTable.scss';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import { RestartAlt, SaveAlt } from '@mui/icons-material';
 
 interface TaxTableProps {
   taxTable: taxBracket[];
@@ -15,9 +21,28 @@ const TaxTable = (props: TaxTableProps) => {
     currency: 'USD',
   });
 
+  const [isEdit, setEdit] = useState(false);
+
+  const getCell = (cellId: string, isEdit: boolean, amount: number) => {
+    return( isEdit
+      ? <TextField id={cellId} type="number" variant="standard" defaultValue={amount} /> 
+      : formatter.format(getPayPeriodValue(amount))
+    )
+  }
+
   return (
     <div className="grid-taxtable">
       <Grid container spacing={2} columns={17}>
+        <Grid xs={17} className="edit-table">
+          <FormGroup>
+            <FormControlLabel
+              control={<Switch defaultChecked={false} onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                setEdit(event.target.checked);
+              }}/>}
+              label="Edit"
+            />
+          </FormGroup>
+        </Grid>
         <Grid xs={2}>
           <div className="column-header"></div>
         </Grid>
@@ -38,17 +63,30 @@ const TaxTable = (props: TaxTableProps) => {
                   <div>{bracket.rate}</div>
                 </Grid>
                 <Grid xs={5}>
-                  <div>{formatter.format(getPayPeriodValue(bracket.over))}</div>
+                  <div>{getCell("over", isEdit, bracket.over)}</div>
                 </Grid>
                 <Grid xs={5}>
-                  <div>{formatter.format(getPayPeriodValue(bracket.under))}</div>
+                  <div>{getCell("under", isEdit, bracket.under)}</div>
                 </Grid>
                 <Grid xs={5}>
-                  <div>{formatter.format(getPayPeriodValue(bracket.plus))}</div>
+                  <div>{getCell("plus", isEdit, bracket.plus)}</div>
                 </Grid>
               </React.Fragment>
             );
           })
+        }
+        {
+          isEdit && <>
+            <Grid xs={11}>
+              <div className="footer-message">Amounts are shown in annual amount in accordance to Tax reports</div>
+            </Grid>
+            <Grid xs={3}>
+              <Button variant="outlined" className="edit-action-btn" startIcon={<RestartAlt />}>Reset</Button>
+            </Grid>
+            <Grid xs={3}>
+              <Button variant="contained" startIcon={<SaveAlt />}>Save</Button>
+            </Grid>
+          </>
         }
       </Grid>
     </div>

--- a/src/common/colors.scss
+++ b/src/common/colors.scss
@@ -1,9 +1,11 @@
 $primary: #d0efff;
 $content-bg: #f5f5f5;
+$white: #ffffff;
 
 $nav-button: $primary;
 $nav-button-active: #eeeeee;
 $nav-button-text: #000000;
 $nav-background: $content-bg;
 
-$grid-taxtable-bg: $nav-button;
+$grid-taxtable-bg: $primary;
+$grid-taxtable-edit-btn-wrapper: $white;


### PR DESCRIPTION
This commit has the following chances:

- Added edit switch to each TaxTable
- Added edit and reset buttons when edit switch is enabled
- Added footer message when edit switch is enabled

Pending items:

- Add functionality to Reset and Save buttons
- Add headless database to save data into
- Consider adding a paycheck to annual toggle for Tax amounts (thus removing the need for the footer message)
- Consider adding a label if the paycheck to annual toggle is added to tell user which amount is being shown